### PR TITLE
ZKR-1240 modifications to halo2 (on tag v2022_08_19) for halo2 analyzer

### DIFF
--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -50,7 +50,8 @@ pub trait Chip<F: FieldExt>: Sized {
 
 /// Index of a region in a layouter
 #[derive(Clone, Copy, Debug)]
-pub struct RegionIndex(usize);
+/// Visibility changed for analyzer
+pub struct RegionIndex(pub usize);
 
 impl From<usize> for RegionIndex {
     fn from(idx: usize) -> RegionIndex {
@@ -88,11 +89,14 @@ impl std::ops::Deref for RegionStart {
 #[derive(Clone, Copy, Debug)]
 pub struct Cell {
     /// Identifies the region in which this cell resides.
-    region_index: RegionIndex,
+    /// Visibility changed for analyzer
+    pub region_index: RegionIndex,
     /// The relative offset of this cell within its region.
-    row_offset: usize,
+    ///  Visibility changed for analyzer
+    pub row_offset: usize,
     /// The column of this cell.
-    column: Column<Any>,
+    /// Visibility changed for analyzer
+    pub column: Column<Any>,
 }
 
 /// An assigned cell.

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -81,12 +81,16 @@ impl Region {
 
 /// The value of a particular cell within the circuit.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CellValue<F: Group + Field> {
+/// Visibility changed for analyzer
+pub enum CellValue<F: Group + Field> {
     // An unassigned cell.
+    /// Visibility changed for analyzer
     Unassigned,
     // A cell that has been assigned a value.
+    /// Visibility changed for analyzer
     Assigned(F),
     // A unique poisoned cell.
+    /// Visibility changed for analyzer
     Poison(usize),
 }
 
@@ -288,7 +292,8 @@ pub struct MockProver<F: Group + Field> {
     current_region: Option<Region>,
 
     // The fixed cells in the circuit, arranged as [column][row].
-    fixed: Vec<Vec<CellValue<F>>>,
+    /// Visibility changed for analyzer
+    pub fixed: Vec<Vec<CellValue<F>>>,
     // The advice cells in the circuit, arranged as [column][row].
     advice: Vec<Vec<CellValue<F>>>,
     // The instance cells in the circuit, arranged as [column][row].

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -23,13 +23,15 @@ pub trait ColumnType:
 /// A column with an index and type
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Column<C: ColumnType> {
-    index: usize,
-    column_type: C,
+    /// Visibility changed for analyzer
+    pub index: usize,
+    /// Visibility changed for analyzer
+    pub column_type: C,
 }
 
 impl<C: ColumnType> Column<C> {
-    #[cfg(test)]
-    pub(crate) fn new(index: usize, column_type: C) -> Self {
+    /// Visibility changed for analyzer
+    pub fn new(index: usize, column_type: C) -> Self {
         Column { index, column_type }
     }
 
@@ -255,7 +257,8 @@ impl TryFrom<Column<Any>> for Column<Instance> {
 /// }
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Selector(pub(crate) usize, bool);
+/// Visibility changed for analyzer
+pub struct Selector(pub usize, bool);
 
 impl Selector {
     /// Enable this selector at the given offset within the given region.
@@ -276,9 +279,11 @@ pub struct FixedQuery {
     /// Query index
     pub(crate) index: usize,
     /// Column index
-    pub(crate) column_index: usize,
+    ///  Visibility changed for analyzer
+    pub column_index: usize,
     /// Rotation of this query
-    pub(crate) rotation: Rotation,
+    ///  Visibility changed for analyzer
+    pub rotation: Rotation,
 }
 
 impl FixedQuery {
@@ -297,11 +302,14 @@ impl FixedQuery {
 #[derive(Copy, Clone, Debug)]
 pub struct AdviceQuery {
     /// Query index
-    pub(crate) index: usize,
+    ///  Visibility changed for analyzer
+    pub index: usize,
     /// Column index
-    pub(crate) column_index: usize,
+    ///  Visibility changed for analyzer
+    pub column_index: usize,
     /// Rotation of this query
-    pub(crate) rotation: Rotation,
+    ///  Visibility changed for analyzer
+    pub rotation: Rotation,
 }
 
 impl AdviceQuery {
@@ -1096,7 +1104,8 @@ impl<F: Field, C: Into<Constraint<F>>, Iter: IntoIterator<Item = C>> IntoIterato
 pub struct Gate<F: Field> {
     name: &'static str,
     constraint_names: Vec<&'static str>,
-    polys: Vec<Expression<F>>,
+    /// Visibility changed for analyzer
+    pub polys: Vec<Expression<F>>,
     /// We track queried selectors separately from other cells, so that we can use them to
     /// trigger debug checks on gates.
     queried_selectors: Vec<Selector>,
@@ -1104,7 +1113,8 @@ pub struct Gate<F: Field> {
 }
 
 impl<F: Field> Gate<F> {
-    pub(crate) fn name(&self) -> &'static str {
+    /// Visibility changed for analyzer
+    pub fn name(&self) -> &'static str {
         self.name
     }
 
@@ -1140,8 +1150,10 @@ pub struct ConstraintSystem<F: Field> {
     /// tooling right now.
     pub(crate) selector_map: Vec<Column<Fixed>>,
 
-    pub(crate) gates: Vec<Gate<F>>,
-    pub(crate) advice_queries: Vec<(Column<Advice>, Rotation)>,
+    /// Visibility changed for analyzer
+    pub gates: Vec<Gate<F>>,
+    /// Visibility changed for analyzer
+    pub advice_queries: Vec<(Column<Advice>, Rotation)>,
     // Contains an integer for each advice column
     // identifying how many distinct queries it has
     // so far; should be same length as num_advice_columns.
@@ -1154,7 +1166,8 @@ pub struct ConstraintSystem<F: Field> {
 
     // Vector of lookup arguments, where each corresponds to a sequence of
     // input expressions and a sequence of table expressions involved in the lookup.
-    pub(crate) lookups: Vec<lookup::Argument<F>>,
+    /// Visibility changed for analyzer
+    pub lookups: Vec<lookup::Argument<F>>,
 
     // Vector of fixed columns, which can be used to store constant values
     // that are copied into advice columns.

--- a/halo2_proofs/src/plonk/lookup.rs
+++ b/halo2_proofs/src/plonk/lookup.rs
@@ -8,8 +8,10 @@ pub(crate) mod verifier;
 #[derive(Clone)]
 pub struct Argument<F: Field> {
     pub(crate) name: &'static str,
-    pub(crate) input_expressions: Vec<Expression<F>>,
-    pub(crate) table_expressions: Vec<Expression<F>>,
+    /// Visibility changed for analyzer
+    pub input_expressions: Vec<Expression<F>>,
+    /// Visibility changed for analyzer
+    pub table_expressions: Vec<Expression<F>>,
 }
 
 impl<F: Field> Debug for Argument<F> {

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -273,7 +273,8 @@ impl<'a, F: Field, B: Basis> Sub<F> for &'a Polynomial<F, B> {
 /// Describes the relative rotation of a vector. Negative numbers represent
 /// reverse (leftmost) rotations and positive numbers represent forward (rightmost)
 /// rotations. Zero represents no rotation.
-#[derive(Copy, Clone, Debug, PartialEq)]
+/// Linter
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
 pub struct Rotation(pub i32);
 
 impl Rotation {

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -273,7 +273,7 @@ impl<'a, F: Field, B: Basis> Sub<F> for &'a Polynomial<F, B> {
 /// Describes the relative rotation of a vector. Negative numbers represent
 /// reverse (leftmost) rotations and positive numbers represent forward (rightmost)
 /// rotations. Zero represents no rotation.
-/// Linter
+/// /// Hash and Eq added for analyzer
 #[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
 pub struct Rotation(pub i32);
 


### PR DESCRIPTION
Summary
This PR makes some necessary modifications to PSE halo2 v2022_08_19 to be used in the analyzer.

Changes:
The visibility of some fields, used in the analyzer, within specific structs has changed to public. The changed files are:
halo2/halo2_proofs/src/circuit.rs
halo2/halo2_proofs/src/dev.rs
halo2/halo2_proofs/src/plonk/circuit.rs
halo2/halo2_proofs/src/plonk/lookup.rs

Added Hash and Eq attributes to the Rotation struct to enable adding it to a Hash set.
The changed file is:
halo2_proofs/src/poly.rs